### PR TITLE
Add two multi-threaded examples for Julia

### DIFF
--- a/julia_threads_dir/Manifest.toml
+++ b/julia_threads_dir/Manifest.toml
@@ -1,0 +1,239 @@
+# This file is machine-generated - editing it directly is not advised
+
+[[ArgCheck]]
+git-tree-sha1 = "dedbbb2ddb876f899585c4ec4433265e3017215a"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.1.0"
+
+[[BangBang]]
+deps = ["Compat", "ConstructionBase", "Future", "InitialValues", "LinearAlgebra", "Requires", "Setfield", "Tables", "ZygoteRules"]
+git-tree-sha1 = "f42321255afc37da855b6cd9f2a1fc36c017ceee"
+uuid = "198e06fe-97b7-11e9-32a5-e1d131e6ad66"
+version = "0.3.29"
+
+[[Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "919c7f3151e79ff196add81d7f4e45d91bbf420b"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.25.0"
+
+[[CompositionsBase]]
+git-tree-sha1 = "f3955eb38944e5dd0fabf8ca1e267d94941d34a5"
+uuid = "a33af91c-f02d-484b-be07-31d278c5ca2b"
+version = "0.1.0"
+
+[[ConstructionBase]]
+git-tree-sha1 = "a2a6a5fea4d6f730ec4c18a76d27ec10e8ec1c50"
+uuid = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+version = "1.0.0"
+
+[[ContextVariablesX]]
+deps = ["Compat", "Logging", "UUIDs"]
+git-tree-sha1 = "fc81d9dd4ffdafb56680f01e6d9db464a6b3689d"
+uuid = "6add18c4-b38d-439d-96f6-d6bc489c04c5"
+version = "0.1.1"
+
+[[DataAPI]]
+git-tree-sha1 = "ad84f52c0b8f05aa20839484dbaf01690b41ff84"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.4.0"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
+
+[[Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[DefineSingletons]]
+git-tree-sha1 = "1a356f194281dff9ef1119faa9125a0d4e210729"
+uuid = "244e2a9f-e319-4986-a169-4d1fe445cd52"
+version = "0.1.0"
+
+[[DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[FLoops]]
+deps = ["Compat", "FLoopsBase", "JuliaVariables", "MLStyle", "Setfield", "Transducers"]
+git-tree-sha1 = "6d0830bffc733b3e4d4d1a7e7109d0a51d68495d"
+uuid = "cc61a311-1640-44b5-9fba-1b764f453329"
+version = "0.1.4"
+
+[[FLoopsBase]]
+deps = ["ContextVariablesX"]
+git-tree-sha1 = "cf3d8b2527be12d204d06aba922b30339a9653dd"
+uuid = "b9860ae5-e623-471e-878b-f6a53c775ea6"
+version = "0.1.0"
+
+[[Future]]
+deps = ["Random"]
+uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
+
+[[InitialValues]]
+git-tree-sha1 = "26c8832afd63ac558b98a823265856670d898b6c"
+uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
+version = "0.2.10"
+
+[[InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
+
+[[JuliaVariables]]
+deps = ["MLStyle", "NameResolution"]
+git-tree-sha1 = "e0fcfa0a2f6122fbe13603764c5310dde00c5593"
+uuid = "b14d175d-62b4-44ba-8fb7-3064adc8c3ec"
+version = "0.2.3"
+
+[[LibGit2]]
+deps = ["Printf"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[LinearAlgebra]]
+deps = ["Libdl"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[MLStyle]]
+git-tree-sha1 = "937eda9ce36fcce082a42edd7181c8d23f4eb550"
+uuid = "d8e11817-5142-5d16-987a-aa16d5891078"
+version = "0.4.6"
+
+[[MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.6"
+
+[[Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[MicroCollections]]
+deps = ["BangBang", "Setfield"]
+git-tree-sha1 = "e991b6a9d38091c4a0d7cd051fcb57c05f98ac03"
+uuid = "128add7d-3638-4c79-886c-908ea0c25c34"
+version = "0.1.0"
+
+[[Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[NameResolution]]
+deps = ["PrettyPrint"]
+git-tree-sha1 = "1a0fa0e9613f46c9b8c11eee38ebb4f590013c5e"
+uuid = "71a1bf82-56d0-4bbc-8a3c-48b961074391"
+version = "0.1.5"
+
+[[Pkg]]
+deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[PrettyPrint]]
+git-tree-sha1 = "632eb4abab3449ab30c5e1afaa874f0b98b586e4"
+uuid = "8162dcfd-2161-5ef2-ae6c-7681170c5f98"
+version = "0.2.0"
+
+[[Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[Random]]
+deps = ["Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "e05c53ebc86933601d36212a93b39144a2733493"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.1.1"
+
+[[SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[Setfield]]
+deps = ["ConstructionBase", "Future", "MacroTools", "Requires"]
+git-tree-sha1 = "d5640fc570fb1b6c54512f0bd3853866bd298b3e"
+uuid = "efcf1570-3423-57d1-acb7-fd33fddbac46"
+version = "0.7.0"
+
+[[SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[SplittablesBase]]
+deps = ["Setfield", "Test"]
+git-tree-sha1 = "ab80edcbd61a44a4dc489d06ead964a863c0a898"
+uuid = "171d559e-b47b-412a-8079-5efa626c420e"
+version = "0.1.10"
+
+[[Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "b1ad568ba658d8cbb3b892ed5380a6f3e781a81e"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.0"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "240d19b8762006ff04b967bdd833269ad642d550"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.2.2"
+
+[[Test]]
+deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[Transducers]]
+deps = ["ArgCheck", "BangBang", "CompositionsBase", "DefineSingletons", "Distributed", "InitialValues", "Logging", "Markdown", "MicroCollections", "Requires", "Setfield", "SplittablesBase", "Tables"]
+git-tree-sha1 = "80f9fad2026c304f391198d391a0c698b666b201"
+uuid = "28d57a85-8fef-5791-bfe6-a80928e7c999"
+version = "0.4.53"
+
+[[UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[ZygoteRules]]
+deps = ["MacroTools"]
+git-tree-sha1 = "9e7a1e8ca60b742e508a315c17eef5211e7fbfd7"
+uuid = "700de1a5-db45-46bc-99cf-38207098b444"
+version = "0.2.1"

--- a/julia_threads_dir/Project.toml
+++ b/julia_threads_dir/Project.toml
@@ -1,0 +1,5 @@
+[deps]
+FLoops = "cc61a311-1640-44b5-9fba-1b764f453329"
+
+[compat]
+FLoops = "0.1"

--- a/julia_threads_dir/README.md
+++ b/julia_threads_dir/README.md
@@ -1,0 +1,26 @@
+# Julia multi-threaded implementations
+
+This folder contains two multi-threaded implementations in Julia:
+
+* `pi.jl` uses the low-level `Threads.@threads` macro;
+* `pi_floops.jl` uses an external package,
+  [`FLoops.jl`](https://github.com/JuliaFolds/FLoops.jl), to implement the
+  parallel reduction.
+
+To run the first example, use
+```
+./run.sh
+```
+use instead
+```
+./run_floops.sh
+```
+for the `FLoops.jl`-based example.  `./run_floops.sh` will also take care of
+installing the package for you --- this operation can take a while, depending on
+how slow/fast is Git in your system.
+
+Julia uses the environment variable `JULIA_NUM_THREADS` to set the number of
+threads to use in a process, or the `-t`/`--threads` flags to the `julia`
+command (this flag is available only in Julia v1.5+).  If you run the example
+using the `./run*.sh` wrappers, you can also use the `OMP_NUM_THREADS`
+environment variable instead of `JULIA_NUM_THREADS`.

--- a/julia_threads_dir/pi.jl
+++ b/julia_threads_dir/pi.jl
@@ -1,0 +1,48 @@
+#!/usr/bin/env julia
+
+using Base.Threads
+
+function _picalc(numsteps)
+    slice = 1.0 / numsteps
+
+    sums = zeros(Float64, nthreads())
+    n = cld(numsteps, nthreads())
+
+    Threads.@threads for i in 1:nthreads()
+        sum_thread = 0.0
+        @simd for j in (1 + (i - 1) * n):min(numsteps, i * n)
+            x = (j - 0.5) * slice
+            sum_thread += 4.0 / (1.0 + x ^ 2)
+        end
+        sums[threadid()] = sum_thread
+    end
+
+    return sum(sums) * slice
+end
+
+function picalc(numsteps)
+
+    println("Calculating PI using:")
+    println("  ", numsteps, " slices")
+    println("  ", nthreads(), " thread(s)")
+
+    start = time()
+    mypi = _picalc(numsteps)
+    elapsed = time() - start
+
+    println("Obtained value of PI: ", mypi)
+    println("Time taken: ", elapsed, " seconds")
+
+end
+
+numsteps = if length(ARGS) > 0
+    parse(Int, ARGS[1])
+else
+    1_000_000_000
+end
+
+# Warm up kernel
+_picalc(10)
+
+# Run the full example
+picalc(numsteps)

--- a/julia_threads_dir/pi_floops.jl
+++ b/julia_threads_dir/pi_floops.jl
@@ -1,0 +1,41 @@
+#!/usr/bin/env julia
+
+using Base.Threads, FLoops
+
+function _picalc(numsteps)
+    slice = 1.0 / numsteps
+
+    @floop @simd for i = 1:numsteps
+        x = (i - 0.5) * slice
+        @reduce(sum += 4.0 / (1.0 + x ^ 2))
+    end
+
+    return sum * slice
+end
+
+function picalc(numsteps)
+
+    println("Calculating PI using:")
+    println("  ", numsteps, " slices")
+    println("  ", nthreads(), " thread(s)")
+
+    start = time()
+    mypi = _picalc(numsteps)
+    elapsed = time() - start
+
+    println("Obtained value of PI: ", mypi)
+    println("Time taken: ", elapsed, " seconds")
+
+end
+
+numsteps = if length(ARGS) > 0
+    parse(Int, ARGS[1])
+else
+    1_000_000_000
+end
+
+# Warm up kernel
+_picalc(10)
+
+# Run the full example
+picalc(numsteps)

--- a/julia_threads_dir/run.sh
+++ b/julia_threads_dir/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -z "${JULIA_NUM_THREADS}" ]]; then
+    export JULIA_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+fi
+
+julia pi.jl "${@}"

--- a/julia_threads_dir/run_floops.sh
+++ b/julia_threads_dir/run_floops.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+if [[ -z "${JULIA_NUM_THREADS}" ]]; then
+    export JULIA_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+fi
+
+# This makes sure you load the right packages to run the example
+julia -e "using Pkg; Pkg.update(); Pkg.activate(\"${PWD}\"); Pkg.instantiate()"
+
+julia --project="${PWD}" pi_floops.jl "${@}"


### PR DESCRIPTION
I added a directory with two multithreaded examples for Julia:

* one uses the low-level built-in `Threads.@threads` macro
* the other one uses the [`FLoops.jl`](https://github.com/JuliaFolds/FLoops.jl) package, which makes writing multi-threaded reductions simpler and less error-prone (you don't have to play with indices arithmetic, and also using SIMD instructions is way simpler).

I do a dummy call to the kernel with a small number of steps to warm up.

Benchmarks on Myriad:
```
$ OMP_NUM_THREADS=1 ./run.sh 
Calculating PI using:
  1000000000 slices
  1 thread(s)
Obtained value of PI: 3.1415926535898455
Time taken: 0.8806970119476318 seconds
$ OMP_NUM_THREADS=18 ./run.sh 
Calculating PI using:
  1000000000 slices
  18 thread(s)
Obtained value of PI: 3.141592653589797
Time taken: 0.05102109909057617 seconds

$ OMP_NUM_THREADS=1 ./run_floops.sh
   # Wait for installation of packages.......
Calculating PI using:
  1000000000 slices
  1 thread(s)
Obtained value of PI: 3.1415926535898437
Time taken: 0.8845429420471191 seconds
$ OMP_NUM_THREADS=18 ./run_floops.sh 
   # Go and brew another cup of coffee........
Calculating PI using:
  1000000000 slices
  18 thread(s)
Obtained value of PI: 3.14159265358979
Time taken: 0.05775904655456543 seconds
```

For comparison, this is the benchmark of the Fortran+OpenMP example compiled with ifort:
```
$ OMP_NUM_THREADS=1 ./run.sh 
rm -f *.o pi
make -f Makefile.intel
make[1]: Entering directory `/lustre/home/cceamgi/repo/pi_examples/fortran_omp_pi_dir'
ifort -O2 -xHost -o pi -fopenmp pi.f90
make[1]: Leaving directory `/lustre/home/cceamgi/repo/pi_examples/fortran_omp_pi_dir'
Calculating PI using:
                        1000000000 slices
                                 1 OpenMP threads
Obtained value of PI: 3.1415926536
Time taken:                0.87537 seconds
$ OMP_NUM_THREADS=18 ./run.sh 
rm -f *.o pi
make -f Makefile.intel
make[1]: Entering directory `/lustre/home/cceamgi/repo/pi_examples/fortran_omp_pi_dir'
ifort -O2 -xHost -o pi -fopenmp pi.f90
make[1]: Leaving directory `/lustre/home/cceamgi/repo/pi_examples/fortran_omp_pi_dir'
Calculating PI using:
                        1000000000 slices
                                18 OpenMP threads
Obtained value of PI: 3.1415926536
Time taken:                0.05136 seconds
```