### PR TITLE
[c_hybrid_mpi+openmp_dir] Fix name of executable

### DIFF
--- a/c_hybrid_mpi+openmp_dir/run.sh
+++ b/c_hybrid_mpi+openmp_dir/run.sh
@@ -2,4 +2,4 @@
 
 make clean
 make
-mpirun ./hybrid-pi
+mpirun ./hybrid_pi


### PR DESCRIPTION
The Makefile builds a program called `hybrid_pi`