### PR TITLE
Use `mapreduce` for Julia functional example

### DIFF
--- a/julia_func_pi_dir/pi.jl
+++ b/julia_func_pi_dir/pi.jl
@@ -1,6 +1,6 @@
 #!/usr/bin/env julia
 
-p(n) = (reduce(+,map((x->(4/(1+(x*x)))),(0.5/n):(1/n):1))/n)
+p(n) = mapreduce(x -> (4 / (1 + (x * x))), +, (0.5 / n):(1 / n):1) / n
 
 function picalc(numsteps)
 
@@ -20,15 +20,22 @@ function picalc(numsteps)
   elapsed = (stop - start)
 
   println("Obtained value of PI: ", mypi)
-  println("Time taken: ", elapsed, " seconds")
+  println("Time taken: ", round(elapsed; digits=3), " seconds")
 
 end
 
-numsteps=50000000
-
-if length(ARGS) > 0
-  numsteps = parse(Int, ARGS[1])
+const numsteps = if length(ARGS) > 0
+    parse(Int, ARGS[1])
+else
+    1_000_000_000
 end
 
+# Warm up kernel
+print("  Warming up...")
+warms = time()
+p(10)
+warmt = time() - warms
+println("done. [", round(warmt; digits=3), "s]\n")
+
+# Run the full example
 picalc(numsteps)
-


### PR DESCRIPTION
`mapreduce` combines `reduce` and `map` into a single function, avoiding
allocating intermediate arrays.  This improves performance by a factor of ~3.

Some benchmarks on Myriad.  Before PR:
```console
[cceamgi@login13 julia_func_pi_dir]$ ./run.sh 
Calculating PI using:
  50000000 slices
  1 worker(s)
Obtained value of PI: 3.1415926535897936
Time taken: 0.4528329372406006 seconds
[cceamgi@login13 julia_func_pi_dir]$ ./run.sh 1000000000
Calculating PI using:
  1000000000 slices
  1 worker(s)
Obtained value of PI: 3.141592653589793
Time taken: 12.335363149642944 seconds
```

After PR:
```console
[cceamgi@login13 julia_func_pi_dir]$ ./run.sh 
  Warming up...done. [0.262s]

Calculating PI using:
  1000000000 slices
  1 worker(s)
Obtained value of PI: 3.141592653589793
Time taken: 4.437 seconds
```