### PR TITLE
Optimise Rust build

### DIFF
--- a/rust_pi_dir/Makefile
+++ b/rust_pi_dir/Makefile
@@ -1,7 +1,7 @@
 RC = rustc
 
 pi: pi.rs Makefile
-	rustc pi.rs
+	rustc -O pi.rs
 
 clean:
 	rm -f pi

--- a/rust_pi_dir/pi.rs
+++ b/rust_pi_dir/pi.rs
@@ -14,7 +14,7 @@ fn main() {
     let my_pi: f64;
     let arguments = std::env::args();
 
-    num_steps = 100000000;
+    num_steps = 1000000000;
 
 // Check OMP_NUM_THREADS.  If it doesn't exist, default to threads = 1.
     match env::var("OMP_NUM_THREADS") {


### PR DESCRIPTION
Benchmarks on Myriad.  Before PR:
```console
[cceamgi@login13 rust_pi_dir]$ ./run.sh
rm -f pi
rustc pi.rs
Calculating PI using:
  100000000 slices
  1 threads
Obtained value of PI: 3.1415926535904264
Time Elapsed: 5.997680755 seconds
```
After PR:
```console
[cceamgi@login13 rust_pi_dir]$ ./run.sh
rm -f pi
rustc -O pi.rs
Calculating PI using:
  100000000 slices
  1 threads
Obtained value of PI: 3.1415926535904264
Time Elapsed: 0.186200917 seconds
```

I didn't look at the code, but I'm not sure this is using a single thread:
```console
[cceamgi@login13 rust_pi_dir]$ for threads in 2 3 6 9 12 18 36; do OMP_NUM_THREADS=${threads} ./pi; done
Calculating PI using:
  100000000 slices
  2 threads
Obtained value of PI: 3.14159265358991
Time Elapsed: 0.93205899 seconds
Calculating PI using:
  100000000 slices
  3 threads
Obtained value of PI: 3.14159265358957
Time Elapsed: 0.62696469 seconds
Calculating PI using:
  100000000 slices
  6 threads
Obtained value of PI: 3.1415926535896452
Time Elapsed: 0.33730942 seconds
Calculating PI using:
  100000000 slices
  9 threads
Obtained value of PI: 3.1415926535895653
Time Elapsed: 0.21291425 seconds
Calculating PI using:
  100000000 slices
  12 threads
Obtained value of PI: 3.141592653589828
Time Elapsed: 0.16279886 seconds
Calculating PI using:
  100000000 slices
  18 threads
Obtained value of PI: 3.141592653589857
Time Elapsed: 0.11736555 seconds
Calculating PI using:
  100000000 slices
  36 threads
Obtained value of PI: 3.141592653589821
Time Elapsed: 0.11877296 seconds
```
~0.18 seconds is close to performance of 12 threads, definitely way faster than 2 threads.