### PR TITLE
Set `basesize` for threaded executor of Julia FLoops example

### DIFF
--- a/julia_floops_pi_dir/pi_floops.jl
+++ b/julia_floops_pi_dir/pi_floops.jl
@@ -5,7 +5,7 @@ using Base.Threads, FLoops
 function _picalc(numsteps)
     slice = 1.0 / numsteps
 
-    @floop @simd for i = 1:numsteps
+    @floop ThreadedEx(;simd=true, basesize=numsteps÷1000) for i = 1:numsteps
         x = (i - 0.5) * slice
         @reduce(sum += 4.0 / (1.0 + x ^ 2))
     end


### PR DESCRIPTION
I noticed that on Myriad the CPU FLoops example was ~10% slower than the other Julia threaded example:
```console
[cceamgi@login12 julia_floops_pi_dir]$ JULIA_NUM_THREADS=18 julia --project pi_floops.jl 100000000000
  Warming up...done. [0.549s]

Calculating PI using:
  100000000000 slices
  18 thread(s)
Obtained value of PI: 3.141592653589794
Time taken: 5.472 seconds
[cceamgi@login13 julia_threads_dir]$ JULIA_NUM_THREADS=18 ./run.sh 100000000000
  Warming up...done. [0.153s]

Calculating PI using:
  100000000000 slices
  18 thread(s)
Obtained value of PI: 3.1415926535897793
Time taken: 4.871 seconds
```
but we can recover basically the same performance by tweaking the value of `basesize` of [`ThreadedEx`](https://juliafolds.github.io/Transducers.jl/stable/reference/manual/#Transducers.ThreadedEx).  With this PR:
```console
[cceamgi@login12 julia_floops_pi_dir]$ JULIA_NUM_THREADS=18 julia --project pi_floops.jl 100000000000
  Warming up...done. [0.577s]

Calculating PI using:
  100000000000 slices
  18 thread(s)
Obtained value of PI: 3.1415926535897922
Time taken: 4.882 seconds
```