### PR TITLE
[julia-ipu] Do manual loop unrolling for better performance in some cases

### DIFF
--- a/julia_ipu_pi_dir/.gitignore
+++ b/julia_ipu_pi_dir/.gitignore
@@ -1,0 +1,1 @@
+/Manifest.toml

--- a/julia_ipu_pi_dir/Project.toml
+++ b/julia_ipu_pi_dir/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+IPUToolkit = "92e0b95a-4011-435a-96f4-10064551ddbe"
+
+[compat]
+IPUToolkit = "1"
+julia = "1.6"

--- a/julia_ipu_pi_dir/README.md
+++ b/julia_ipu_pi_dir/README.md
@@ -1,0 +1,53 @@
+# Graphcore IPU implementation in Julia
+
+This is an implementation of the pi example in the Julia programming language for running on [Graphcore IPUs](https://www.graphcore.ai/products/ipu), using the package [`IPUToolkit.jl`](https://github.com/JuliaIPU/IPUToolkit.jl) developed among others by the [UCL Centre for Advanced Research Computing](https://www.ucl.ac.uk/advanced-research-computing).
+To run this example you will need a version of Julia compatible with the Poplar SDK you are using, see the [documentation of `IPUToolkit.jl`](https://juliaipu.github.io/IPUToolkit.jl/) for more details.
+The first time you run the benchmark the package will be installed automatically, this also involves compiling a C++ wrapper around the Poplar SDK, which can take up to ~6-7 minutes, please be patient.
+Subsequent runs should be much faster, as the package will be already installed.
+
+The program is parallelised across all the tiles of the attached IPU.
+Like the equivalent [C++ program](../cpp_ipu_pi_dir), this uses single precision floating point numbers, so the result may not be very accurate.
+
+Contrary to most of the other implementations in this repository, this script takes two arguments:
+
+1. a [loop unrolling](https://en.wikipedia.org/wiki/Loop_unrolling) factor, which can sensibly speed-up the code.
+   The default is to use a loop unrolling of 1, so that no manual loop unrolling is done.
+2. `n`, rather than the number of slices.
+   The number of slices used = n * number of IPU tiles.
+   By default `n` is set to `typemax(UInt32) ÷ num_tiles`.
+   `n` must be an integer multiple of the loop unrolling factor, an error is thrown if that's not the case.
+
+## Examples
+
+```console
+[cceamgi@mandelbrot julia_ipu_pi_dir]$ ./run.sh
+[ Info: Trying to attach to device 0...
+[ Info: Successfully attached to device 0
+✓ Compiling codelet Pi: 	 Time: 0:00:04
+Calculating PI using:
+  4294966272 slices
+  1472 IPU tiles
+  loop unroll factor 1
+Obtained value of PI: 3.1499734
+Time taken: 0.1325 seconds (245093526 cycles at 1.85 GHz)
+[cceamgi@mandelbrot julia_ipu_pi_dir]$ ./run.sh 12
+[ Info: Trying to attach to device 0...
+[ Info: Successfully attached to device 0
+✓ Compiling codelet Pi: 	 Time: 0:00:04
+Calculating PI using:
+  4294966272 slices
+  1472 IPU tiles
+  loop unroll factor 12
+Obtained value of PI: 3.1499734
+Time taken: 0.07492 seconds (138594708 cycles at 1.85 GHz)
+[cceamgi@mandelbrot julia_ipu_pi_dir]$ ./run.sh 2 1000
+[ Info: Trying to attach to device 0...
+[ Info: Successfully attached to device 0
+✓ Compiling codelet Pi: 	 Time: 0:00:04
+Calculating PI using:
+  1472000 slices
+  1472 IPU tiles
+  loop unroll factor 2
+Obtained value of PI: 3.1415932
+Time taken: 3.098e-5 seconds (57318 cycles at 1.85 GHz)
+```

--- a/julia_ipu_pi_dir/pi.jl
+++ b/julia_ipu_pi_dir/pi.jl
@@ -1,5 +1,12 @@
 #!/usr/bin/env julia
 
+# Activate and precompile the current environment
+using Pkg
+Pkg.activate(@__DIR__; io=devnull)
+Pkg.instantiate(; io=devnull)
+Pkg.precompile(; io=devnull)
+
+# Program starts here
 using IPUToolkit.IPUCompiler, IPUToolkit.Poplar
 
 ENV["POPLAR_RUNTIME_OPTIONS"] = """{"target.hostSyncTimeout":"20"}"""
@@ -8,8 +15,40 @@ device = Poplar.get_ipu_device()
 target = Poplar.DeviceGetTarget(device)
 graph = Poplar.Graph(target)
 
+function print_usage(unroll, n)
+    println(stderr, """
+                    Usage:
+                        julia $(@__FILE__) [loop unroll factor] [n]
+                    Default values are
+                        unroll factor: $(unroll)
+                        n: $(n)
+                    Examples:
+                        julia $(@__FILE__) 2
+                        julia $(@__FILE__) 4 729444
+                    """)
+end
+
 num_tiles = Int(Poplar.TargetGetNumTiles(target))
-n::UInt32 = typemax(UInt32) ÷ num_tiles
+n::UInt32, unroll::UInt32 = let
+    # Default values of n and the loop unrolling factor
+    n = typemax(UInt32) ÷ num_tiles
+    unroll = UInt32(1)
+    # Parse command line arguments, if any
+    if length(ARGS) ≤ 2
+        if length(ARGS) ≥ 1
+            unroll = parse(UInt32, ARGS[1])
+        end
+        if length(ARGS) == 2
+            n = parse(UInt32, ARGS[2])
+        end
+    else
+        print_usage(unroll, n)
+        exit(1)
+    end
+    # Make sure n is an integer multiple of the loop unrolling factor before returning
+    iszero(rem(n, unroll)) || error("n ($(n)) is not an integer multiple of unroll factor ($(unroll))")
+    n, unroll
+end
 num_steps::UInt32 = num_tiles * n
 slice::Float32 = 1 / num_steps
 
@@ -21,9 +60,13 @@ cycles = similar(ids)
 
 @eval function pi_kernel(i::T) where {T<:Integer}
     sum = 0f0
-    for j in (i * $(n)):((i + one(T)) * $(n) - one(T))
-        x = (j - 5f-1) * $(slice)
-        sum += 4 / (1 + x ^ 2)
+    for j in (i * $(n)):$(unroll):((i + one(T)) * $(n) - one(T))
+        # Do manual loop unrolling, sometimes this can be better than what the
+        # compiler can do.
+        Base.Cartesian.@nexprs $(Int64(unroll)) idx -> begin
+            x = (j + Float32(idx - 1) - 5f-1) * $(slice)
+            sum += 4f0 / (1f0 + x ^ 2)
+        end
     end
     return sum
 end
@@ -31,26 +74,31 @@ end
 @codelet graph function Pi(in::VertexVector{UInt32, In},
                            out::VertexVector{Float32, Out},
                            cycles::VertexVector{UInt32, Out})
+    # Each tile deals with one-element vectors only.  In `out` we store the result of the
+    # kernel, in `cycles` we store the cycles count on this tile.
     cycles[begin] = @ipuelapsed(out[begin] = pi_kernel(in[begin]))
 end
 
-input = Poplar.GraphAddConstant(graph, ids)
-output = similar(graph, input, Float32, "sums");
-cs = similar(graph, input, UInt32, "cycles");
+ids_ipu = Poplar.GraphAddConstant(graph, ids)
+sums_ipu = similar(graph, sums, "sums");
+cycles_ipu = similar(graph, cycles, "cycles");
 
 prog = Poplar.ProgramSequence()
 
-add_vertex(graph, prog, 0:(num_tiles - 1), Pi, input, output, cs)
+add_vertex(graph, prog, 0:(num_tiles - 1), Pi, ids_ipu, sums_ipu, cycles_ipu)
 
-Poplar.GraphCreateHostRead(graph, "sums-read", output)
-Poplar.GraphCreateHostRead(graph, "cycles-read", cs)
+Poplar.GraphCreateHostRead(graph, "sums-read", sums_ipu)
+Poplar.GraphCreateHostRead(graph, "cycles-read", cycles_ipu)
 
-engine = Poplar.Engine(graph, prog)
+flags = Poplar.OptionFlags()
+Poplar.OptionFlagsSet(flags, "debug.instrument", "true")
+
+engine = Poplar.Engine(graph, prog, flags)
 Poplar.EngineLoadAndRun(engine, device)
 Poplar.EngineReadTensor(engine, "sums-read", sums)
 Poplar.EngineReadTensor(engine, "cycles-read", cycles)
 
-Poplar.DeviceDetach(device)
+Poplar.detach_devices()
 
 pi = sum(sums) * slice
 time = round(maximum(cycles) / tile_clock_frequency; sigdigits=4)
@@ -59,6 +107,7 @@ print("""
       Calculating PI using:
         $(num_steps) slices
         $(num_tiles) IPU tiles
+        loop unroll factor $(Int(unroll))
       Obtained value of PI: $(pi)
       Time taken: $(time) seconds ($(maximum(cycles)) cycles at $(round(tile_clock_frequency / 1e9; sigdigits=3)) GHz)
       """)

--- a/julia_ipu_pi_dir/run.sh
+++ b/julia_ipu_pi_dir/run.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-julia pi.jl
+julia pi.jl "${@}"


### PR DESCRIPTION
On Mandelbrot we have a znver2 CPU and Julia isn't able to do aggressive loop unrolling when targeting the host, luckily we can do manual loop unrolling quite easily with the [`Base.Cartesian.@nexprs`](https://docs.julialang.org/en/v1/devdocs/cartesian/#Base.Cartesian.@nexprs) macro:
```console
[cceamgi@mandelbrot julia_ipu_pi_dir]$ julia pi.jl 1
[ Info: Trying to attach to device 0...
[ Info: Successfully attached to device 0
✓ Compiling codelet Pi:          Time: 0:00:04
Calculating PI using:
  4294966272 slices
  1472 IPU tiles
  loop unroll factor 1
Obtained value of PI: 3.1499734
Time taken: 0.1325 seconds (245093526 cycles at 1.85 GHz)
[cceamgi@mandelbrot julia_ipu_pi_dir]$ julia pi.jl 2
[ Info: Trying to attach to device 0...
[ Info: Successfully attached to device 0
✓ Compiling codelet Pi:          Time: 0:00:04
Calculating PI using:
  4294966272 slices
  1472 IPU tiles
  loop unroll factor 2
Obtained value of PI: 3.1499734
Time taken: 0.0899 seconds (166313574 cycles at 1.85 GHz)
[cceamgi@mandelbrot julia_ipu_pi_dir]$ julia pi.jl 4
[ Info: Trying to attach to device 0...
[ Info: Successfully attached to device 0
✓ Compiling codelet Pi:          Time: 0:00:04
Calculating PI using:
  4294966272 slices
  1472 IPU tiles
  loop unroll factor 4
Obtained value of PI: 3.1499734
Time taken: 0.08517 seconds (157560252 cycles at 1.85 GHz)
[cceamgi@mandelbrot julia_ipu_pi_dir]$ julia pi.jl 8
[ Info: Trying to attach to device 0...
[ Info: Successfully attached to device 0
✓ Compiling codelet Pi:          Time: 0:00:04
Calculating PI using:
  4294966272 slices
  1472 IPU tiles
  loop unroll factor 8
Obtained value of PI: 3.1499734
Time taken: 0.0828 seconds (153183588 cycles at 1.85 GHz)
[cceamgi@mandelbrot julia_ipu_pi_dir]$ julia pi.jl 12
[ Info: Trying to attach to device 0...
[ Info: Successfully attached to device 0
✓ Compiling codelet Pi:          Time: 0:00:04
Calculating PI using:
  4294966272 slices
  1472 IPU tiles
  loop unroll factor 12
Obtained value of PI: 3.1499734
Time taken: 0.07492 seconds (138594708 cycles at 1.85 GHz)
```

Note: this requires https://github.com/JuliaRegistries/General/pull/87432 to be merged in a couple of days.