### PR TITLE
Fix type of iterator in `c_hybrid_mpi+openmp`

### DIFF
--- a/c_hybrid_mpi+openmp_dir/hybrid_pi.c
+++ b/c_hybrid_mpi+openmp_dir/hybrid_pi.c
@@ -7,7 +7,7 @@ int main( int argc, char **argv ) {
   double step, x, sum, total_sum, pi, start, stop, min_start, max_stop;
   int this_proc, num_procs, remainder;
   long int my_slice[2];
-  int i;
+  long int i;
 
   MPI_Init(&argc,&argv);
   MPI_Comm_size(MPI_COMM_WORLD,&num_procs);


### PR DESCRIPTION
`int` can be too small to deal with large number of steps, and `long int` matches the type of `num_steps` https://github.com/UCL-RITS/pi_examples/blob/09f685ae96e8abe69d009cb5e461c36c979c4267/c_hybrid_mpi%2Bopenmp_dir/hybrid_pi.c#L6 Also, this matches what's done in `c_pi`: https://github.com/UCL-RITS/pi_examples/blob/09f685ae96e8abe69d009cb5e461c36c979c4267/c_pi_dir/pi.c#L6

Ref: https://github.com/UCL-RITS/pi_examples/issues/21#issuecomment-2123621687