### PR TITLE
[c_hybrid_mpi+openmp_dir] Allow setting CFLAGS

### DIFF
--- a/c_hybrid_mpi+openmp_dir/Makefile
+++ b/c_hybrid_mpi+openmp_dir/Makefile
@@ -2,12 +2,13 @@ CC=mpicc
 EXEC=hybrid_pi
 SOURCES=$(wildcard *.c)
 OBJECTS=$(SOURCES:.c=.o)
+CFLAGS=-O3
 
 $(EXEC): $(OBJECTS)
-	$(CC) -fopenmp -o $(EXEC) $(OBJECTS)
+	$(CC) $(CFLAGS) -fopenmp -o $(EXEC) $(OBJECTS)
 
 %.o: %.c
-	$(CC) -fopenmp -c $< -o $@
+	$(CC) $(CFLAGS) -fopenmp -c $< -o $@
 
 clean:
 	rm -f $(EXEC) $(OBJECTS)


### PR DESCRIPTION
Also, default optimisation level to `-O3`.