### PR TITLE
Add Julia implementation using `OhMyThreads.jl`

### DIFF
--- a/julia_ohmythreads_pi_dir/.gitignore
+++ b/julia_ohmythreads_pi_dir/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/julia_ohmythreads_pi_dir/Project.toml
+++ b/julia_ohmythreads_pi_dir/Project.toml
@@ -1,0 +1,8 @@
+[deps]
+OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[compat]
+OhMyThreads = "0.7"
+Pkg = "1"
+julia = "1.10"

--- a/julia_ohmythreads_pi_dir/pi.jl
+++ b/julia_ohmythreads_pi_dir/pi.jl
@@ -1,0 +1,48 @@
+#!/usr/bin/env julia
+
+using Pkg
+Pkg.activate(@__DIR__)
+Pkg.resolve()
+Pkg.instantiate()
+
+using Base.Threads: nthreads
+using OhMyThreads: tmapreduce
+
+function _picalc(numsteps)
+    slice = 1 / numsteps
+
+    return tmapreduce(+, 1:numsteps; ntasks=nthreads()) do i
+        4.0 / (1.0 + ((i - 0.5) * slice) ^ 2)
+    end * slice
+end
+
+function picalc(numsteps)
+
+    println("Calculating PI using:")
+    println("  ", numsteps, " slices")
+    println("  ", nthreads(), " thread(s)")
+
+    start = time()
+    mypi = _picalc(numsteps)
+    elapsed = time() - start
+
+    println("Obtained value of PI: ", mypi)
+    println("Time taken: ", round(elapsed; digits=3), " seconds")
+
+end
+
+numsteps = if length(ARGS) > 0
+    parse(Int, ARGS[1])
+else
+    1_000_000_000
+end
+
+# Warm up kernel
+print("  Warming up...")
+warms = time()
+_picalc(10)
+warmt = time() - warms
+println("done. [", round(warmt; digits=3), "s]\n")
+
+# Run the full example
+picalc(numsteps)

--- a/julia_ohmythreads_pi_dir/run.sh
+++ b/julia_ohmythreads_pi_dir/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+if [[ -z "${JULIA_NUM_THREADS}" ]]; then
+    export JULIA_NUM_THREADS="${OMP_NUM_THREADS:-1}"
+fi
+
+julia pi.jl "${@}"


### PR DESCRIPTION
[`OhMyThreads.jl`](https://github.com/JuliaFolds2/OhMyThreads.jl) is a new-ish package which provides user-friendly threading constructs, for example it comes with a multithreaded map reduce, which is perfect for this program.  Compare the implementation in this PR https://github.com/UCL-RITS/pi_examples/blob/bdd72c150a5f2b45465f4b5b2448296d9368c283/julia_ohmythreads_pi_dir/pi.jl#L11-L17 with the current multithreaded implementation: https://github.com/UCL-RITS/pi_examples/blob/fc92267c33b8ffb0e51e55083c71d5fb9926bfac/julia_threads_dir/pi.jl#L5-L21

Some benchmarks: on Nvidia Grace-Grace, with this implementation using Julia v1.11.1 I get
```console
$ julia -t 144 pi.jl 1000000000000
  Activating project at `~/repo/pi_examples/julia_ohmythreads_dir`
  No Changes to `~/repo/pi_examples/julia_ohmythreads_dir/Project.toml`
  No Changes to `~/repo/pi_examples/julia_ohmythreads_dir/Manifest.toml`
  Warming up...done. [0.195s]

Calculating PI using:
  1000000000000 slices
  144 thread(s)
Obtained value of PI: 3.1415926535897936
Time taken: 5.458 seconds
```
With `julia_threads_pi_dir` (same version of Julia as above):
```console
$ julia -t 144 pi.jl 1000000000000
  Warming up...done. [0.095s]

Calculating PI using:
  1000000000000 slices
  144 thread(s)
Obtained value of PI: 3.141592653588557
Time taken: 5.441 seconds
```
With `c_omp_pi_dir`:
```console
$ make -B CC=gcc COPTS='-O2 -fopenmp -march=native' && OMP_NUM_THREADS=144 ./pi 1000000000000
gcc -O2 -fopenmp -march=native  -c pi.c -o pi.o
gcc -O2 -fopenmp -march=native  -o pi pi.o
Calculating PI using:
  1000000000000 slices
  144 thread(s)
Obtained value for PI: 3.14159265358896
Time taken:            5.77358439611271 seconds
$ gcc --version
gcc (GCC) 14.1.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```
With `fortran_omp_pi_dir`:
```console
$ make -Bf Makefile.gfortran FOPT='-O2 -fopenmp -march=native' && ./pi 1000000000000
gfortran -O2 -fopenmp -march=native -o pi pi.f90
Calculating PI using:
                     1000000000000 slices
                               144 OpenMP threads
Obtained value of PI: 3.1415926536
Time taken:                5.72090 seconds
$ gfortran --version
GNU Fortran (GCC) 14.1.0
Copyright (C) 2024 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```